### PR TITLE
Add vitals metrics and crash logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ A lightweight Android library that provides a simple wrapper around OpenTelemetr
 - 📊 **Tracing**: Distributed tracing with OpenTelemetry
 - 📈 **Metrics**: Built-in metrics collection
 - 📝 **Structured Logging**: Log collection with different severity levels
+- 📊 **App Vitals**: Memory and CPU usage exported automatically
+- 🛑 **Crash Reporting**: Uncaught exceptions are logged
 - 🚀 **Easy Integration**: Simple setup and initialization
 - 🔌 **Grafana LGTM Ready**: Pre-configured for Grafana's observability stack
 - 🛡️ **Production Ready**: Built with performance and reliability in mind

--- a/telemetry/src/main/java/com/bazaar/telemetry/TelemetryService.kt
+++ b/telemetry/src/main/java/com/bazaar/telemetry/TelemetryService.kt
@@ -28,7 +28,8 @@ interface TelemetryService {
     fun log(
         level: LogLevel,
         message: String,
-        attrs: Attributes = Attributes.empty()
+        attrs: Attributes = Attributes.empty(),
+        throwable: Throwable? = null
     )
 
     fun incRequestCount(


### PR DESCRIPTION
## Summary
- automatically collect memory and CPU usage metrics
- capture uncaught exceptions and log them via `TelemetryManager`
- extend `log` API to accept a `Throwable`
- document new vitals and crash features

## Testing
- `gradle test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_b_6862892a823c832088e5dcf92cf18504