### PR TITLE
feat: Configure Maven Central publishing for Meesum Telemetry SDK

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,40 @@
 android.useAndroidX=true
 android.enableJetifier=true
+
+# -----------------------------------------------------------------------------
+# Publishing Properties for Maven Central (Sonatype OSSRH)
+#
+# IMPORTANT:
+# DO NOT STORE YOUR ACTUAL CREDENTIALS IN THIS FILE IF IT'S VERSION CONTROLLED.
+# Instead, place them in your global Gradle properties file, typically located at:
+#   - ~/.gradle/gradle.properties (on Linux/macOS)
+#   - C:\Users\<YourUser>\.gradle\gradle.properties (on Windows)
+#
+# These are the properties you'll need to define there:
+# -----------------------------------------------------------------------------
+
+# --- Sonatype OSSRH (Maven Central) Credentials ---
+# sonatypeUsername=your_sonatype_jira_username
+# sonatypePassword=your_sonatype_jira_password_or_token
+
+# --- GPG Signing Key Details ---
+# Ensure you have GPG installed and a key pair generated.
+# The key ID is usually the last 8 characters of your key's fingerprint.
+# signing.keyId=YOUR_GPG_KEY_ID_LAST_8_CHARS
+# signing.password=YOUR_GPG_KEY_PASSPHRASE
+# signing.secretKeyRingFile=/path/to/your/secring.gpg
+#   OR for GPG versions 2.1+ that don't use secring.gpg by default,
+#   you might need to export the key: gpg --export-secret-keys YOUR_KEY_ID > my-secret-key.gpg
+#   then set: signing.secretKeyRingFile=/path/to/my-secret-key.gpg
+#   Alternatively, for modern Gradle versions, you might be able to use in-memory key representations
+#   or let the signing plugin use GPG agent / default GPG key if configured.
+#   Check Gradle signing plugin documentation for the most up-to-date practices.
+
+# --- Library Version (Optional - can also be defined in build.gradle.kts) ---
+# libraryVersion=1.0.0
+
+# --- Group ID (Optional - can also be defined in build.gradle.kts) ---
+# libraryGroupId=com.yourcompany.yourlibrary
+
+# You can also use environment variables or prompt for these if you prefer,
+# see Gradle documentation for more details on managing credentials.

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -11,6 +11,8 @@ pluginManagement {
         id("com.android.library")                     version "8.3.1"
         kotlin("android")                             version "1.9.23"
         id("org.jetbrains.kotlin.plugin.serialization") version "1.9.23"
+        id("org.jetbrains.dokka")                     version "1.9.20" // Added for KDoc/Javadoc generation
+        id("io.github.gradle-nexus.publish-plugin")   version "2.0.0" // Added for Sonatype publishing
     }
 }
 

--- a/telemetry/build.gradle.kts
+++ b/telemetry/build.gradle.kts
@@ -4,12 +4,16 @@ plugins {
     /* inherits Kotlin 2.0.0 from settings.gradle/pluginManagement */
     kotlin("android")
     kotlin("plugin.serialization")
+    id("org.jetbrains.dokka") // For KDoc/Javadoc generation
     id("maven-publish")
+    signing // For GPG signing artifacts
+    id("io.github.gradle-nexus.publish-plugin") // For simplifying Sonatype publishing
+    `java-library` // To help with sourcesJar and javadocJar
 }
 
 /* ───────── Android ───────── */
 android {
-    namespace  = "com.bazaar.telemetry"
+    namespace  = "io.github.meesum.telemetry" // Changed to reflect new groupId
     compileSdk = 34
 
     defaultConfig { minSdk = 21 }
@@ -19,7 +23,34 @@ android {
         targetCompatibility = JavaVersion.VERSION_21
     }
     kotlin { jvmToolchain(21) }
+    publishing {
+        singleVariant("release") {
+            withSourcesJar()
+            withJavadocJar() // This will be configured via Dokka
+        }
+    }
 }
+
+// Task to generate Javadoc using Dokka for the release build and package it as a JAR
+val dokkaJavadoc by tasks.registering(org.jetbrains.dokka.gradle.DokkaTask::class) {
+    moduleName.set(project.name)
+    outputDirectory.set(file("$buildDir/dokkaJavadoc"))
+    dokkaSourceSets {
+        named("main") {
+            // Configure source set specifics if needed
+            // Dokka should pick up sources from the Android plugin by default for the 'main' source set
+            // Ensure this captures sources for the 'release' variant.
+            // May need to explicitly point to android.sourceSets.main.java.srcDirs
+        }
+    }
+}
+
+val androidJavadocJar by tasks.registering(Jar::class) {
+    dependsOn(dokkaHtml)
+    archiveClassifier.set("javadoc")
+    from(dokkaHtml.flatMap { it.outputDirectory })
+}
+
 
 /* ───────── Deps ───────── */
 dependencies {
@@ -46,11 +77,85 @@ dependencies {
     testImplementation("io.opentelemetry:opentelemetry-sdk-testing:1.49.0") // For testing OpenTelemetry
 }
 
+// Placeholder values -
+// TODO: It's highly recommended to move these to gradle.properties or define them centrally
+// especially groupId and version.
+// Changed groupId to reflect "meesum"
+val libraryGroupId = "io.github.meesum.telemetry" // TODO: Replace with your actual groupId registered with Sonatype (e.g., com.meesum.telemetry if you own meesum.com)
+val libraryArtifactId = "telemetry" // ArtifactId remains "telemetry" under the new group
+val libraryVersion = "1.0.0" // TODO: Replace with your actual version (e.g., read from gradle.properties)
+
+val libraryName = "Meesum Telemetry SDK" // TODO: Replace with your library's name
+val libraryDescription = "An Android SDK for collecting and exporting telemetry data." // TODO: Replace with your library's description
+val siteUrl = "https://github.com/your-org/your-repo" // TODO: Replace with your project's website or SCM URL
+val gitUrl = "https://github.com/your-org/your-repo.git" // TODO: Replace with your Git repository URL
+
+val licenseName = "The Apache License, Version 2.0" // TODO: Replace with your license
+val licenseUrl = "https://www.apache.org/licenses/LICENSE-2.0.txt"
+
+val developerId = "your-username" // TODO: Replace with your developer ID (e.g., GitHub username)
+val developerName = "Your Name or Company" // TODO: Replace
+val developerEmail = "you@example.com" // TODO: Replace
+
 publishing {
-    publications.create<MavenPublication>("release") {
-        afterEvaluate { from(components["release"]) }   // publish the AAR
-        groupId    = "com.bazaar.telemetry"
-        artifactId = "telemetry"
-        version    = "1.0.0"
+    publications {
+        create<MavenPublication>("release") {
+            // Use the task that generates Dokka Javadoc for Android
+            artifact(tasks.named("androidJavadocJar")) {
+                classifier = "javadoc"
+            }
+            // Sources jar should be included by withSourcesJar() in android.publishing block
+
+            afterEvaluate { from(components["release"]) } // publish the AAR from the release build variant
+
+            groupId = libraryGroupId
+            artifactId = libraryArtifactId
+            version = libraryVersion
+
+            pom {
+                name.set(libraryName)
+                description.set(libraryDescription)
+                url.set(siteUrl)
+
+                licenses {
+                    license {
+                        name.set(licenseName)
+                        url.set(licenseUrl)
+                    }
+                }
+                developers {
+                    developer {
+                        id.set(developerId)
+                        name.set(developerName)
+                        email.set(developerEmail)
+                    }
+                }
+                scm {
+                    connection.set("scm:git:$gitUrl")
+                    developerConnection.set("scm:git:ssh:${gitUrl.substringAfter("https://")}") // ssh variant
+                    url.set(siteUrl)
+                }
+            }
+        }
+    }
+}
+
+// Configure signing of publications
+// Credentials for signing will be typically stored in ~/.gradle/gradle.properties
+// e.g., signing.keyId, signing.password, signing.secretKeyRingFile
+signing {
+    sign(publishing.publications["release"])
+}
+
+// Configure Nexus Publishing (Sonatype OSSRH)
+// Credentials for Sonatype will be typically stored in ~/.gradle/gradle.properties
+// e.g., sonatypeUsername, sonatypePassword
+nexusPublishing {
+    repositories {
+        sonatype { // Name of the repository configuration
+            nexusUrl.set(uri("https://s01.oss.sonatype.org/service/local/")) // Sonatype v2 URL
+            snapshotRepositoryUrl.set(uri("https://s01.oss.sonatype.org/content/repositories/snapshots/")) // Sonatype v2 snapshot URL
+            // username and password will be taken from gradle properties: sonatypeUsername, sonatypePassword
+        }
     }
 }


### PR DESCRIPTION
Sets up the necessary Gradle plugins (maven-publish, signing, nexus-publish) and configurations in `telemetry/build.gradle.kts` to enable publishing the SDK to Sonatype OSSRH (Maven Central).

Key changes:
- Added `maven-publish`, `signing`, `java-library`, `org.jetbrains.dokka`, and `io.github.gradle-nexus.publish-plugin`.
- Configured generation of AAR, Javadoc JAR (using Dokka), and sources JAR.
- Added POM metadata with placeholders for project-specific details (name, description, URL, license, developers, SCM).
- Renamed `groupId` to `io.github.meesum.telemetry` and updated Android namespace and library name placeholder accordingly.
- Added `signing` configuration block to sign artifacts using GPG.
- Added `nexusPublishing` block to configure Sonatype OSSRH repositories.
- Added comments in `gradle.properties` to guide the user on setting up Sonatype and GPG credentials in their global `~/.gradle/gradle.properties` file.

The user will need to:
1. Create a Sonatype JIRA account and request publishing rights for the `io.github.meesum.telemetry` groupId (or their chosen equivalent).
2. Generate GPG keys and distribute the public key.
3. Fill in all `TODO` placeholder values in `telemetry/build.gradle.kts`.
4. Configure their `~/.gradle/gradle.properties` with Sonatype credentials and GPG key details.